### PR TITLE
Remove the salt field from the user model, as it's redundant

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -8,7 +8,7 @@ passport.serializeUser((user, done) => {
 
 passport.deserializeUser(async (id, done) => {
   try {
-    const user = await User.findById(id, '-password -salt')
+    const user = await User.findById(id, '-password')
     done(null, user)
   } catch(err) {
     done(err)

--- a/src/middleware/validators.js
+++ b/src/middleware/validators.js
@@ -16,7 +16,7 @@ export async function ensureUser(ctx, next) {
     ctx.throw(401)
   }
 
-  const user = await User.findById(decoded.id, '-password -salt')
+  const user = await User.findById(decoded.id, '-password')
   if (!user) {
     ctx.throw(401)
   }

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -7,8 +7,7 @@ const User = new mongoose.Schema({
   type: { type: String, default: 'User' },
   name: { type: String },
   username: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
-  salt: { type: String }
+  password: { type: String, required: true }
 })
 
 User.pre('save', function preSave(next) {
@@ -29,7 +28,6 @@ User.pre('save', function preSave(next) {
       if (err) { throw new Error(err) }
 
       user.password = hash
-      user.salt = salt
 
       next(null)
     })

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -64,7 +64,6 @@ export async function authUser(ctx, next) {
     const response = user.toJSON()
 
     delete response.password
-    delete response.salt
 
     ctx.body = {
       token,

--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -50,8 +50,7 @@ export async function createUser(ctx) {
   const response = user.toJSON()
 
   delete response.password
-  delete response.salt
-
+  
   ctx.body = {
     user: response,
     token
@@ -86,7 +85,7 @@ export async function createUser(ctx) {
  * @apiUse TokenError
  */
 export async function getUsers(ctx) {
-  const users = await User.find({}, '-password -salt')
+  const users = await User.find({}, '-password')
   ctx.body = { users }
 }
 
@@ -119,7 +118,7 @@ export async function getUsers(ctx) {
  */
 export async function getUser(ctx, next) {
   try {
-    const user = await User.findById(ctx.params.id, '-password -salt')
+    const user = await User.findById(ctx.params.id, '-password')
     if (!user) {
       ctx.throw(404)
     }

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -39,7 +39,6 @@ describe('Auth', () => {
           res.body.user.should.have.property('username')
           res.body.user.username.should.equal('test')
           expect(res.body.user.password).to.not.exist
-          expect(res.body.user.salt).to.not.exist
 
           context.user = res.body.user
           context.token = res.body.token

--- a/test/users.spec.js
+++ b/test/users.spec.js
@@ -33,7 +33,6 @@ describe('Users', () => {
           res.body.user.should.have.property('username')
           res.body.user.username.should.equal('supercoolname')
           expect(res.body.user.password).to.not.exist
-          expect(res.body.user.salt).to.not.exist
 
           context.user = res.body.user
           context.token = res.body.token
@@ -99,7 +98,6 @@ describe('Users', () => {
           res.body.should.have.property('user')
 
           expect(res.body.user.password).to.not.exist
-          expect(res.body.user.salt).to.not.exist
 
           done()
         })
@@ -138,7 +136,6 @@ describe('Users', () => {
           res.body.user.should.have.property('username')
           res.body.user.username.should.equal('updatedcoolname')
           expect(res.body.user.password).to.not.exist
-          expect(res.body.user.salt).to.not.exist
 
           done()
         })


### PR DESCRIPTION
The way bcrypt works, we don't need to store the salt alongside the password in the user model. The salt is already part of the hash that bcrypt generates.

See the bcrypt section of [this article](http://dustwell.com/how-to-handle-passwords-bcrypt.html) for more details on that.

Basically:

```
Let's dissect that output string a little:
```

![image](https://cloud.githubusercontent.com/assets/1094085/14144993/163cd382-f660-11e5-93f3-ee5293e039b8.png)

```
As you can see, it stores both the salt, and the hashed output in the string.
```
