### PR TITLE
Use authorization header instead of query parameter for jwt

### DIFF
--- a/src/middleware/validators.js
+++ b/src/middleware/validators.js
@@ -1,23 +1,7 @@
 import User from '../models/users'
 import config from '../../config'
+import { getToken } from '../utils/auth'
 import { verify } from 'jsonwebtoken'
-
-function getToken(ctx) {
-  const header = ctx.request.header.authorization
-  if (!header) {
-    return null
-  }
-  const parts = header.split(' ')
-  if (parts.length !== 2) {
-    return null
-  }
-  const scheme = parts[0]
-  const token = parts[1]
-  if (/^Bearer$/i.test(scheme)) {
-    return token
-  }
-  return null
-}
 
 export async function ensureUser(ctx, next) {
   const token = getToken(ctx)

--- a/src/middleware/validators.js
+++ b/src/middleware/validators.js
@@ -2,8 +2,25 @@ import User from '../models/users'
 import config from '../../config'
 import { verify } from 'jsonwebtoken'
 
+function getToken(ctx) {
+  const header = ctx.request.header.authorization
+  if (!header) {
+    return null
+  }
+  const parts = header.split(' ')
+  if (parts.length !== 2) {
+    return null
+  }
+  const scheme = parts[0]
+  const token = parts[1]
+  if (/^Bearer$/i.test(scheme)) {
+    return token
+  }
+  return null
+}
+
 export async function ensureUser(ctx, next) {
-  const { token } = ctx.query
+  const token = getToken(ctx)
 
   if (!token) {
     ctx.throw(401)

--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -50,7 +50,7 @@ export async function createUser(ctx) {
   const response = user.toJSON()
 
   delete response.password
-  
+
   ctx.body = {
     user: response,
     token

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,16 @@
+export function getToken(ctx) {
+  const header = ctx.request.header.authorization
+  if (!header) {
+    return null
+  }
+  const parts = header.split(' ')
+  if (parts.length !== 2) {
+    return null
+  }
+  const scheme = parts[0]
+  const token = parts[1]
+  if (/^Bearer$/i.test(scheme)) {
+    return token
+  }
+  return null
+}

--- a/test/users.spec.js
+++ b/test/users.spec.js
@@ -43,18 +43,52 @@ describe('Users', () => {
   })
 
   describe('GET /users', () => {
+    it('should not fetch users if the authorization header is missing', (done) => {
+      request
+        .get('/users')
+        .set('Accept', 'application/json')
+        .expect(401, done)
+    })
+
+    it('should not fetch users if the authorization header is missing the scheme', (done) => {
+      request
+        .get('/users')
+        .set({
+          Accept: 'application/json',
+          Authorization: '1'
+        })
+        .expect(401, done)
+    })
+
+    it('should not fetch users if the authorization header has invalid scheme', (done) => {
+      const { token } = context
+      request
+        .get('/users')
+        .set({
+          Accept: 'application/json',
+          Authorization: 'Unknown ${token}'
+        })
+        .expect(401, done)
+    })
+
     it('should not fetch users if token is invalid', (done) => {
       request
-        .get('/users?token=1')
-        .set('Accept', 'application/json')
+        .get('/users')
+        .set({
+          Accept: 'application/json',
+          Authorization: 'Bearer 1'
+        })
         .expect(401, done)
     })
 
     it('should fetch all users', (done) => {
       const { token } = context
       request
-        .get(`/users?token=${token}`)
-        .set('Accept', 'application/json')
+        .get('/users')
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .expect(200, (err, res) => {
           if (err) { return done(err) }
 
@@ -70,16 +104,22 @@ describe('Users', () => {
   describe('GET /users/:id', () => {
     it('should not fetch user if token is invalid', (done) => {
       request
-        .get('/users/1?token=1')
-        .set('Accept', 'application/json')
+        .get('/users/1')
+        .set({
+          Accept: 'application/json',
+          Authorization: 'Bearer 1'
+        })
         .expect(401, done)
     })
 
     it('should throw 404 if user doesn\'t exist', (done) => {
       const { token } = context
       request
-        .get(`/users/1?token=${token}`)
-        .set('Accept', 'application/json')
+        .get('/users/1')
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .expect(404, done)
     })
 
@@ -90,8 +130,11 @@ describe('Users', () => {
       } = context
 
       request
-        .get(`/users/${_id}?token=${token}`)
-        .set('Accept', 'application/json')
+        .get(`/users/${_id}`)
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .expect(200, (err, res) => {
           if (err) { return done(err) }
 
@@ -107,16 +150,22 @@ describe('Users', () => {
   describe('PUT /users/:id', () => {
     it('should not update user if token is invalid', (done) => {
       request
-        .put('/users/1?token=1')
-        .set('Accept', 'application/json')
+        .put('/users/1')
+        .set({
+          Accept: 'application/json',
+          Authorization: 'Bearer 1'
+        })
         .expect(401, done)
     })
 
     it('should throw 404 if user doesn\'t exist', (done) => {
       const { token } = context
       request
-        .put(`/users/1?token=${token}`)
-        .set('Accept', 'application/json')
+        .put('/users/1')
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .expect(404, done)
     })
 
@@ -127,8 +176,11 @@ describe('Users', () => {
       } = context
 
       request
-        .put(`/users/${_id}?token=${token}`)
-        .set('Accept', 'application/json')
+        .put(`/users/${_id}`)
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .send({ user: { username: 'updatedcoolname' } })
         .expect(200, (err, res) => {
           if (err) { return done(err) }
@@ -145,16 +197,22 @@ describe('Users', () => {
   describe('DELETE /users/:id', () => {
     it('should not delete user if token is invalid', (done) => {
       request
-        .delete('/users/1?token=1')
-        .set('Accept', 'application/json')
+        .delete('/users/1')
+        .set({
+          Accept: 'application/json',
+          Authorization: 'Bearer 1'
+        })
         .expect(401, done)
     })
 
     it('should throw 404 if user doesn\'t exist', (done) => {
       const { token } = context
       request
-        .delete(`/users/1?token=${token}`)
-        .set('Accept', 'application/json')
+        .delete('/users/1')
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .expect(404, done)
     })
 
@@ -165,8 +223,11 @@ describe('Users', () => {
       } = context
 
       request
-        .delete(`/users/${_id}?token=${token}`)
-        .set('Accept', 'application/json')
+        .delete(`/users/${_id}`)
+        .set({
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        })
         .expect(200, done)
     })
   })


### PR DESCRIPTION
Hi :)

This pull request changes the way that the server accepts the auth token, we'd take it from Authorization header instead of the query parameter, as suggested here: 

https://jwt.io/introduction/

> Whenever the user wants to access a protected route or resource, it should send the JWT, typically in the Authorization header using the Bearer schema. Therefore the content of the header should look like the following.
> 
> Authorization Bearer **token**

We could still accept the token via query for backwards compatibility if needed. I didn't update the package version since you'd probably want to do it on your own.

We could also import the getToken method from a utils / helpers file if needed to make the middleware a little bit more clear. I didn't want to enforce anything here, so if you have any suggestions then I'll happily change it.

Let me know what you think!

Best,
Emil
